### PR TITLE
fix error on returning calcChecksum

### DIFF
--- a/pms7003-photon-demo-1/pms7003-photon-demo-1.ino
+++ b/pms7003-photon-demo-1/pms7003-photon-demo-1.ino
@@ -191,7 +191,6 @@ bool pms7003_read() {
                     Particle.publish("Data1", printbuf, 60, PRIVATE);
                     packetReceived = true;
                     detectOff = 0;
-                    calcChecksum = 0;
                     inFrame = false;
                 }
             }


### PR DESCRIPTION
when pms7003_read() function is returned, (calcChecksum == thisFrame.checksum); is always 0. because of calcChecksum is 0